### PR TITLE
Fixes alias_method_chain DEPRECATIONs in Rails 5

### DIFF
--- a/lib/postgres_ext/active_record/5.0/relation/predicate_builder/array_handler.rb
+++ b/lib/postgres_ext/active_record/5.0/relation/predicate_builder/array_handler.rb
@@ -5,27 +5,31 @@ require 'active_support/concern'
 
 module ActiveRecord
   class PredicateBuilder
+
+    module CallWithFeature
+      def call(attribute, value)
+        column = case attribute.try(:relation)
+                 when Arel::Nodes::TableAlias, NilClass
+                 else
+                   cache = ActiveRecord::Base.connection.schema_cache
+                   if cache.data_source_exists? attribute.relation.name
+                     cache.columns(attribute.relation.name).detect{ |col| col.name.to_s == attribute.name.to_s }
+                   end
+                 end
+        if column && column.respond_to?(:array) && column.array
+          attribute.eq(value)
+        else
+          super(attribute, value)
+        end
+      end
+    end
+
+
     module ArrayHandlerPatch
       extend ActiveSupport::Concern
 
       included do
-        def call_with_feature(attribute, value)
-          column = case attribute.try(:relation)
-                   when Arel::Nodes::TableAlias, NilClass
-                   else
-                     cache = ActiveRecord::Base.connection.schema_cache
-                     if cache.data_source_exists? attribute.relation.name
-                       cache.columns(attribute.relation.name).detect{ |col| col.name.to_s == attribute.name.to_s }
-                     end
-                   end
-          if column && column.respond_to?(:array) && column.array
-            attribute.eq(value)
-          else
-            call_without_feature(attribute, value)
-          end
-        end
-
-        alias_method_chain(:call, :feature)
+        prepend CallWithFeature
       end
 
       module ClassMethods

--- a/lib/postgres_ext/active_record/relation.rb
+++ b/lib/postgres_ext/active_record/relation.rb
@@ -9,7 +9,7 @@ require 'postgres_ext/active_record/relation/query_methods'
 
 if ar_5_0_version_cutoff
   require 'postgres_ext/active_record/5.0/relation/predicate_builder/array_handler'
-elsif ar_4_2_version_cutuff
+elsif ar_4_2_version_cutoff
   require 'postgres_ext/active_record/relation/predicate_builder/array_handler'
 else
   require 'postgres_ext/active_record/4.x/relation/predicate_builder'

--- a/lib/postgres_ext/active_record/relation/query_methods.rb
+++ b/lib/postgres_ext/active_record/relation/query_methods.rb
@@ -1,5 +1,22 @@
 module ActiveRecord
+
+  module BuildArelWithExtension
+    def build_arel
+      arel = super
+
+      build_with(arel)
+
+      build_rank(arel, rank_value) if rank_value
+
+      arel
+    end
+  end
+
+
   module QueryMethods
+
+    prepend BuildArelWithExtension
+
     class WhereChain
       def overlap(opts, *rest)
         substitute_comparisons(opts, rest, Arel::Nodes::Overlap, 'overlap')
@@ -189,16 +206,6 @@ module ActiveRecord
       self
     end
 
-    def build_arel_with_extensions
-      arel = build_arel_without_extensions
-
-      build_with(arel)
-
-      build_rank(arel, rank_value) if rank_value
-
-      arel
-    end
-
     def build_with(arel)
       with_statements = with_values.flat_map do |with_value|
         case with_value
@@ -255,6 +262,6 @@ module ActiveRecord
       end
     end
 
-    alias_method_chain :build_arel, :extensions
   end
 end
+


### PR DESCRIPTION
## Changes proposed in this pull request
Fixes
DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from <module:QueryMethods> at .../postgres_ext/lib/postgres_ext/active_record/relation/query_methods.rb:258)

and

DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from block in <module:ArrayHandlerPatch> at .../postgres_ext/lib/postgres_ext/active_record/5.0/relation/predicate_builder/array_handler.rb:28)